### PR TITLE
Single character expression in RegExp

### DIFF
--- a/src/main/kotlin/com/mrkirby153/botcore/command/args/ArgumentParser.kt
+++ b/src/main/kotlin/com/mrkirby153/botcore/command/args/ArgumentParser.kt
@@ -20,7 +20,7 @@ class ArgumentParser(private val arguments: Array<String>, private val argumentT
         for (i in 0 until argumentTypes.size) {
             var argument = argumentTypes[i]
             val argType = ArgType.determine(argument)
-            argument = argument.replace(Regex("<|>|\\[|]"), "")
+            argument = argument.replace(Regex("[<>\[\]]"), "")
             val parts = argument.split(":")
             val name = parts[0]
             val type = parts[1]


### PR DESCRIPTION
It is simpler and significantly faster to use a character class.